### PR TITLE
Adaptation to dark themes

### DIFF
--- a/data/index.css
+++ b/data/index.css
@@ -47,13 +47,13 @@
 
 .tabbrowser-tab:hover {
   border-color: rgba(0,0,0, .2);
-  background: rgba(255,255,255, .5);
+  background: rgba(255,255,255, .3);
   margin-bottom: 1px;
 }
 
 .tabbrowser-tab[visuallyselected=true] {
   border-color: rgba(0,0,0, .3);
-  background: rgba(255,255,255, .85);
+  background: rgba(255,255,255, .5);
   margin-bottom: 1px;
 }
 


### PR DESCRIPTION
Adjusting the opacity of the background colors of (1) the hovering tab,
and (2) the selected tab. In this way the tab title is readable even
with a dark theme where the text color is light.

Issue #5.